### PR TITLE
Fix drupal10 upgrade status warning

### DIFF
--- a/cleverdisplay/cleverdisplay.info.yml
+++ b/cleverdisplay/cleverdisplay.info.yml
@@ -1,7 +1,6 @@
 name: Cleverdisplay
 description: 'Theming utilities module by Clever age, designed to be used in addition with cleverdrop base theme'
 type: module
-core: 8.x
 dependencies:
 version: 8.x-1.0
-core_version_requirement: ^8 || ^9
+core_version_requirement: ^9 || ^10

--- a/cleverdrop.info.yml
+++ b/cleverdrop.info.yml
@@ -2,9 +2,8 @@ name: Cleverdrop
 type: theme
 description: 'Base theme by Clever age, provide common tools and minimal html'
 version: 8.1.0
-core: 8.x
 hidden: true
-core_version_requirement: ^8 || ^9
+core_version_requirement: ^9 || ^10
 base theme: false
 
 libraries:

--- a/templates/form/form_input/select.html.twig
+++ b/templates/form/form_input/select.html.twig
@@ -1,4 +1,4 @@
-{% spaceless %}
+{% apply spaceless %}
   <select{{ attributes }}>
     {% for option in options %}
       {% if option.type == 'optgroup' %}
@@ -12,4 +12,4 @@
       {% endif %}
     {% endfor %}
   </select>
-{% endspaceless %}
+{% endapply %}


### PR DESCRIPTION
in *.info.yml : 
 - removes core: 8.x, 
 - add core_version_requirement: ^9 || ^10

replace twig spaceless tag (`{% spaceless %}{% endspaceless %}`) tags by twig 3 spaceless filter (`{% apply spaceless %}{% endapply %}`)

